### PR TITLE
trivial patch, please pull

### DIFF
--- a/src/org/stathissideris/ascii2image/text/TextGrid.java
+++ b/src/org/stathissideris/ascii2image/text/TextGrid.java
@@ -1533,7 +1533,7 @@ public class TextGrid {
 		//remove blank rows at the bottom
 		boolean done = false;
 		int i;
-		for(i = lines.size() - 1; !done; i--){
+		for(i = lines.size() - 1; i >= 0 && !done; i--){
 			StringBuilder row = lines.get(i);
 			if(!StringUtils.isBlank(row.toString())) done = true;
 		}


### PR DESCRIPTION
[1]  Don't fail with an out-of-bounds error if initialiseWithLines is called with only empty lines
