### PR TITLE
CustomShapeDefinition to provide shapes programmatically

### DIFF
--- a/src/org/stathissideris/ascii2image/graphics/BitmapRenderer.java
+++ b/src/org/stathissideris/ascii2image/graphics/BitmapRenderer.java
@@ -154,8 +154,14 @@ public class BitmapRenderer {
 				float offset = diagram.getMinimumOfCellDimension() / 3.333f;
 			
 				if(path != null
-						&& shape.dropsShadow()
-						&& shape.getType() != DiagramShape.TYPE_CUSTOM){
+						&& shape.dropsShadow()){
+					
+					// X -> && shape.getType() != DiagramShape.TYPE_CUSTOM
+					// Custom types will in general return null for the 
+					// GeneralPath. This condition was therefore superfluous
+					// and in the way to allow the CustomShapeDefinition object
+					// to provide a path
+					
 					GeneralPath shadow = new GeneralPath(path);
 					AffineTransform translate = new AffineTransform();
 					translate.setToTranslation(offset, offset);
@@ -286,7 +292,11 @@ public class BitmapRenderer {
 			if(shape.getType() == DiagramShape.TYPE_STORAGE) {
 				continue;
 			} 
-			if(shape.getType() == DiagramShape.TYPE_CUSTOM){
+			if(shape.getType() == DiagramShape.TYPE_CUSTOM && shape.getDefinition().getPath(shape)==null){
+				
+				// Only render custom shapes when they do not provide 
+				// a path. I.e. getDefinition().getPath() == null
+				
 				renderCustomShape(shape, g2);
 				continue;
 			}
@@ -428,6 +438,16 @@ public class BitmapRenderer {
 			
 //			g2.drawRect(bounds.x, bounds.y, bounds.width, bounds.height); //looks different!			
 		}
+		
+		//
+		// Check if the CustomShapeDefinition can render for us.
+		//
+		if ( definition.render(g2, shape))
+			return;
+
+		//
+		// Try to the svg and png files registered with the ConfigurationParser
+		//
 		
 		//TODO: custom shape distintion relies on filename extension. Make this more intelligent
 		if(definition.getFilename().endsWith(".png")){

--- a/src/org/stathissideris/ascii2image/graphics/CustomShapeDefinition.java
+++ b/src/org/stathissideris/ascii2image/graphics/CustomShapeDefinition.java
@@ -19,6 +19,9 @@
  */
 package org.stathissideris.ascii2image.graphics;
 
+import java.awt.*;
+import java.awt.geom.*;
+
 public class CustomShapeDefinition {
 	private String tag;
 	private boolean stretch = false;
@@ -65,6 +68,42 @@ public class CustomShapeDefinition {
 		this.comment = comment;
 	}
 	
+	/**
+	 * This method can be overridden to provide a custom path back. The
+	 * {@link ProcessingOptions} store {@link CustomShapeDefinition} objects by
+	 * name. In general, these custom shape definitions are read with the
+	 * {@link ConfigurationParser} and consist of pure data. However, this makes
+	 * it hard to extend DITAA with custom shapes from the caller. This method
+	 * is called for Custom Shapes to see if it has a GeneralPath. If this
+	 * returns null, the normal behavior is followed. If not, the path is used
+	 * to provide shadow, stroke, and fill just like the built-in shapes.
+	 * 
+	 * @param shape
+	 *            The shape for which to create a {@link GeneralPath}
+	 */
+	public GeneralPath getPath(DiagramShape shape) {
+		return null;
+	}
+
+	/**
+	 * This method can be overridden to customize the rendering. The
+	 * {@link ProcessingOptions} store {@link CustomShapeDefinition} objects by
+	 * name. In general, these custom shape definitions are read with the
+	 * {@link ConfigurationParser} and consist of pure data. However, this makes
+	 * it hard to extend DITAA with custom shapes from the caller. This method
+	 * is called for Custom Shapes. If it returns {@code false} then the default
+	 * behavior for custom shapes is followed, otherwise the caller must assume
+	 * that the shape has been rendered.
+	 * 
+	 * @param shape
+	 *            The shape for which to create a {@link GeneralPath}
+	 * @param g2
+	 *            The Graphics pen
+	 */
+	public boolean render(Graphics2D g2, DiagramShape shape) {
+		return false;
+	}
+
 	public String toString(){
 		return
 			"Custom shape: \""+getTag()+"\":\n"

--- a/src/org/stathissideris/ascii2image/graphics/DiagramShape.java
+++ b/src/org/stathissideris/ascii2image/graphics/DiagramShape.java
@@ -396,6 +396,17 @@ public class DiagramShape extends DiagramComponent {
 	}
 	
 	public GeneralPath makeIntoRenderPath(Diagram diagram, RenderingOptions options) {
+		
+		//
+		// Allow the CustomShapeDefinition to override
+		// the path for this shape. 
+		//
+		if ( definition != null) {
+			GeneralPath customPath = definition.getPath(this);
+			if ( customPath != null)
+				return customPath;
+		}
+		
 		int size = getPoints().size();
 		
 		if(getType() == TYPE_POINT_MARKER){


### PR DESCRIPTION
The general way to extend DITAA with new shapes is to parse and SVG file and then render this shape with SVG in the output. This is very general but requires the batik libraries to be available. In my case I needed a simple way to extend the shapes programmatically.

It turned out that this was quite easy to do in the design. I added 2 methods to the CustomShapeDefinition. A render method that could completely take over the rendering and a simpler getPath method that can provide a GeneralPath.

If the CustomShapeDefinition can provide a path, this path is used and all options work as they do for the built in types. If there is no path, the render method is called. If this returns false, the standard custom shapes are used.

[I would appreciate it if you could merge this since it seems useful to others and then I don't have to fork this project. Thanks for the good work!]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stathissideris/ditaa/2)
<!-- Reviewable:end -->
