### PR TITLE
getParent should not return null for targetFilename

### DIFF
--- a/src/org/stathissideris/ascii2image/core/HTMLConverter.java
+++ b/src/org/stathissideris/ascii2image/core/HTMLConverter.java
@@ -161,7 +161,7 @@ public class HTMLConverter extends HTMLEditorKit {
 		
 		System.out.println("Generating diagrams... ");
 		
-		File imageDir = new File(new File(targetFilename).getParent() + File.separator + imageDirName);
+		File imageDir = new File(new File(targetFilename).getAbsoluteFile().getParent() + File.separator + imageDirName);
 		if(!imageDir.exists()){
 			if(!imageDir.mkdir()){
 				System.err.println("Could not create directory " + imageDirName);
@@ -171,7 +171,7 @@ public class HTMLConverter extends HTMLEditorKit {
 		
 		for(String URL : diagramList.keySet()) {
 			String text = (String) diagramList.get(URL);
-			String imageFilename = new File(targetFilename).getParent() + File.separator + URL;
+			String imageFilename = new File(targetFilename).getAbsoluteFile().getParent() + File.separator + URL;
 			if(new File(imageFilename).exists() && !options.processingOptions.overwriteFiles()){
 				System.out.println("Error: Cannot overwrite file "+URL+", file already exists." +					" Use the --overwrite option if you would like to allow file overwrite.");
 				continue;


### PR DESCRIPTION
Hi,

"new File(targetFilename).getParent()" return null value if targetFilename is a relative path, use "new File(targetFilename).getAbsoluteFile().getParent()" instead.

Note: For some strange reason the github.com website shows other lines, do not look at it, use "git log -p" to see the changes made.