### PR TITLE
never fill dashed paths (neither closed nor unclosed) in SVG

### DIFF
--- a/src/java/org/stathissideris/ascii2image/graphics/SVGBuilder.java
+++ b/src/java/org/stathissideris/ascii2image/graphics/SVGBuilder.java
@@ -204,9 +204,6 @@ public class SVGBuilder {
             if (shape.getType() == DiagramShape.TYPE_ARROWHEAD) {
                 renderPath(shape, commands, "none", fill);
             }
-
-        } else if (shape.isStrokeDashed()) {
-            fill = "white";
         }
 
         if (shape.getType() != DiagramShape.TYPE_ARROWHEAD) {


### PR DESCRIPTION
Never filling dashed paths is consistent with PNG output.

Also, this fixes erroneous filling of unclosed dashed paths. Without
this fix, such fillings can overlap other parts of the graphics, which
are then partially invisible. Sometimes only shadows are affected. For
example:

    /======
    :       :
    :+----+ :
    :|cABC| :
     +----+ :
            :
     =======/

In this example, the top left corner of the box is cut-off by the
(white) filling of the top left dashed path. Additionally, the lower
right corner of the shadow of the box is cut-off by the (white) filling
of the lower right dashed path.